### PR TITLE
Make karma-gzip work with karma 0.13.22

### DIFF
--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -2,13 +2,19 @@ var path = require('path');
 
 var log = null;
 var compressedFiles = Object.create(null);
+var basePath = null;
 
-function updateFiles(files, gzippedFiles) {
+function relativePath(basePath, filePath) {
+  return filePath.replace(basePath, '');
+}
+
+function filterOutGzippedFiles(files, gzippedFilePaths) {
   var webserverFiles = [];
 
-  files.included.forEach(function(file) {
-    if (gzippedFiles.indexOf(file.path) !== -1) {
-      compressedFiles[path.basename(file.path)] = file;
+  // filter out gzipped files from .served
+  files.served.forEach(function(file) {
+    if (gzippedFilePaths.indexOf(file.path) !== -1) {
+      compressedFiles[relativePath(basePath, file.path)] = file;
     } else {
       webserverFiles.push(file);
     }
@@ -17,58 +23,61 @@ function updateFiles(files, gzippedFiles) {
   files.served = webserverFiles;
 }
 
-// Set Gzip headers on the response
-function setGzipResponseheaders(response) {
-  // var type = mime.lookup(file.originalPath);
-  // var charset = mime.charsets.lookup(type);
-
+// Set gzip headers on the response
+function setGzipHeaders(response) {
   response.setHeader('Content-Type', 'application/javascript; charset=utf-8');
   response.setHeader('Content-Encoding', 'gzip');
   response.setHeader('Vary', 'Accept-Encoding');
 }
 
 // check if the client accepts gzipped responses
-function clientAcceptsGzipEncoding(request) {
+function acceptsGzip(request) {
   // TODO: request.getHeader ???
   return request.headers['accept-encoding'].indexOf('gzip') !== -1;
 }
 
 // Response handler for gzip encoded files
-function responseHandler(request, response) {
-  var url = request.url.substr(1);
-  var urlBasename = path.basename(url).split('?')[0];
-  var file = compressedFiles[urlBasename];
+function gzipResponseHandler(request, response) {
+  var urlPath = request.url.split('?')[0];
+  var file = compressedFiles[ urlPath.replace('/base', '') ];
 
-  if (clientAcceptsGzipEncoding(request)) {
-    log.debug('serving (gzip): ' + file.path);
-    setGzipResponseheaders(response);
+  if (!file) {
+    log.error('Gzipped file not found: ' + request.url);
+    throw new Error('Gzipped file not found: ' + request.url);
+  }
+
+  if (acceptsGzip(request)) {
+    log.debug('found file, serving (gzip): ' + file.path);
+    setGzipHeaders(response);
     response.writeHead(200);
     response.end(file.content);
   } else {
     // TODO: fix this — fall back to non-gzipped response
-    log.error('CLIENT DOES NOT ACCEPT GZIPPED REPSONSES');
+    log.error('Client does not accept gzipped responses');
     throw new Error();
   }
 }
 
-function createGzipFileHandler(gzippedFiles) {
+function createGzipHandler(gzippedFilePaths) {
   return {
-    urlRegex: new RegExp(gzippedFiles.map(path.basename).join('|')),
-    handler: responseHandler
+    urlRegex: new RegExp(gzippedFilePaths.map(relativePath.bind(null, basePath)).join('|')),
+    handler: gzipResponseHandler
   };
 }
 
-function Plugin(gzippedFiles, emitter, logger, customFileHandlers) {
+function Plugin(gzippedFilePaths, emitter, logger, customFileHandlers, configBasePath) {
   log = logger.create('gzip-plugin');
+  basePath = configBasePath;
 
-  emitter.on('file_list_modified', function(filesPromise) {
-    filesPromise.then(function(files) {
-      updateFiles(files, gzippedFiles);
-      customFileHandlers.push(createGzipFileHandler(gzippedFiles));
-    });
+  emitter.on('file_list_modified', function(files) {
+    // create handlers only once, this makes sense only for `watch mode`
+    // assume that file list doesn't change in between watched runs
+    if (Object.keys(compressedFiles).length === 0) {
+      customFileHandlers.push(createGzipHandler(gzippedFilePaths));
+    }
+    filterOutGzippedFiles(files, gzippedFilePaths);
   });
 }
-
 
 // PUBLIC API
 module.exports = Plugin;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var Plugin = require('./Plugin');
 var Preprocessor = require('./Preprocessor');
 
-Plugin.$inject = ['gzippedFilePaths', 'emitter', 'logger', 'customFileHandlers'];
+Plugin.$inject = ['gzippedFilePaths', 'emitter', 'logger', 'customFileHandlers', 'config.basePath'];
 Preprocessor.$inject = ['gzippedFilePaths', 'config.gzip', 'logger', 'helper'];
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-gzip",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "A gzip preprocessor for Karma",
   "main": "lib/index.js",
   "scripts": {
@@ -8,9 +8,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Ferocia/karma-gzip.git"
+    "url": "git@github.com:toptal/karma-gzip.git"
   },
-  "author": "Justin Morris <justin.morris@ferocia.com.au> (http://ferocia.com.au)",
+  "author": {
+    "name": "Justin Morris",
+    "email": "justin.morris@ferocia.com.au",
+    "url": "http://ferocia.com.au"
+  },
+  "contributors": [
+    {
+      "name": "Ilya Furman",
+      "email": "ilya.furman@toptal.com"
+    }
+  ],
   "license": "MIT",
   "keywords": [
     "karma",


### PR DESCRIPTION
- `file_list_modified` event doesn't use filesPromise anymore
- Use relative path instead of basename for gzipped files
- Don't accumulate file handlers on each watcher run, created them once
- Process files.served, this fixes broken static images